### PR TITLE
Remove configFile param since it is already the default

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,6 @@
                         <type>zip</type>
                     </assemblyArtifact>
                     <serverName>${server.name}Server</serverName>
-                    <configFile>src/main/liberty/config/server.xml</configFile>
                     <packageType>${package.type}</packageType>
                     <packageName>${package.name}</packageName>
                     <include>${package.include}</include>


### PR DESCRIPTION
liberty-maven-plugin already uses `src/main/liberty/config/server.xml` as the default location for server.xml.  There is no need to specify it in the pom if just using this default, otherwise it shows warnings such as `[WARNING] The /Users/eric/git/SkillsNetworkLabs/src/main/liberty/config/server.xml file is overwritten by the /Users/eric/git/SkillsNetworkLabs/src/main/liberty/config/server.xml file.`